### PR TITLE
Rename Marionette dependency to match docs

### DIFF
--- a/backbone.marionette.subrouter.js
+++ b/backbone.marionette.subrouter.js
@@ -4,7 +4,7 @@
 
 (function (factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['underscore', 'backbone', 'backbone.marionette'], factory);
+        define(['underscore', 'backbone', 'marionette'], factory);
     } else {
         factory(_, Backbone, Marionette);
     }


### PR DESCRIPTION
In all the examples I've seen, people use "marionette" as the dependency name. Marionette now has an AMD build which uses this name. See: https://github.com/marionettejs/backbone.marionette/wiki/Using-marionette-with-requirejs
