### PR TITLE
Fix Bower package name and version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "Backbone Marionette SubRouter",
-  "version": "0.0.5",
+  "name": "backbone.marionette.subrouter",
+  "version": "0.0.6",
   "homepage": "https://github.com/pushchris/backbone.marionette.subrouter",
   "authors": [
     "Chris Anderson <hi@chrisanderson.io>"


### PR DESCRIPTION
The previous Bower package name was invalid and didn't match the name the package was published under. The package version number was also somehow out of sync with the npm package.