### PR TITLE
Don't set a separator when a sub router prefix isn't given

### DIFF
--- a/backbone.marionette.subrouter.js
+++ b/backbone.marionette.subrouter.js
@@ -20,11 +20,11 @@
             this.prefix = prefix = prefix || "";
  
             // SubRoute instances may be instantiated using a prefix with or without a trailing slash.
-            // If the prefix does *not* have a trailing slash, we need to insert a slash as a separator
-            // between the prefix and the sub-route path for each route that we register with Backbone.
-            this.separator = (prefix.slice(-1) === "/")
-                            ? ""
-                            : "/";
+            // If a prefix is set and it does *not* have a trailing slash, we need to insert a slash as
+            // a separator between the prefix and the sub-route path for each route that we register with Backbone.
+            this.separator = (prefix && prefix.slice(-1) !== "/")
+                ? "/"
+                : "";
  
             // If you want to match "books" and "books/" without creating separate routes, set this
             // option to "true" and the sub-router will automatically create those routes for you.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone.marionette.subrouter",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "homepage": "https://github.com/pushchris/backbone.marionette.subrouter",
   "authors": [
     "Chris Anderson <hi@chrisanderson.io>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "backbone.marionette.subrouter",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"description": "Backbone.marionette.subrouter extends the functionality of Backbone Marionette router such that each of an application's modules can define its own module-specific routes.",
     "homepage": "https://github.com/pushchris/backbone.marionette.subrouter",
     "author": {


### PR DESCRIPTION
Previously, if you didn't set the optional sub router prefix, your `appRoutes` would automatically be prefixed with a slash, resulting in route regular expressions that never matched anything.
